### PR TITLE
feat: Hono サーバー起動 + ヘルスチェック

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vp run dev",
+    "dev:server": "pnpm --filter @loopback/server dev",
     "build": "vp run build",
     "check": "vp run check",
     "test": "vp test",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,10 +6,15 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@loopback/db": "workspace:*"
+    "@loopback/db": "workspace:*",
+    "hono": "^4.7.0",
+    "@hono/node-server": "^1.14.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+export const app = new Hono();
+
+app.get("/api/health", (c) => {
+  return c.json({ status: "ok" });
+});

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { app } from "./app.js";
+
+describe("GET /api/health", () => {
+  it("returns status ok", async () => {
+    const res = await app.request("/api/health");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,2 +1,6 @@
-// @loopback/server — entry point (placeholder)
-export {}
+import { serve } from "@hono/node-server";
+import { app } from "./app.js";
+
+serve({ fetch: app.fetch, port: 3000 }, (info) => {
+  console.log(`Server listening on http://localhost:${info.port}`);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 5.9.3
       vite-plus:
         specifier: ^0.1.0
-        version: 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))
+        version: 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
 
   packages/cli:
     dependencies:
@@ -42,9 +42,19 @@ importers:
 
   packages/server:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.0
+        version: 1.19.11(hono@4.12.8)
       '@loopback/db':
         specifier: workspace:*
         version: link:../db
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.8
+    devDependencies:
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
 
   packages/web:
     dependencies:
@@ -63,13 +73,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))
+        version: 4.7.0(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite-plus:
         specifier: ^0.1.0
-        version: 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))
+        version: 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
 
 packages:
 
@@ -601,6 +611,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1421,6 +1437,10 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1731,6 +1751,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -2183,6 +2208,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2451,7 +2480,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2459,11 +2488,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)
+      vite: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)':
+  '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)':
     dependencies:
       '@oxc-project/runtime': 0.115.0
       '@oxc-project/types': 0.115.0
@@ -2473,6 +2502,7 @@ snapshots:
       '@types/node': 22.19.15
       esbuild: 0.27.4
       fsevents: 2.3.3
+      tsx: 4.21.0
       typescript: 5.9.3
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.11':
@@ -2487,11 +2517,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.11':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))':
+  '@voidzero-dev/vite-plus-test@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)
+      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -2501,7 +2531,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      vite: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)
+      vite: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
       ws: 8.19.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -2709,7 +2739,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -2744,6 +2773,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
+
+  hono@4.12.8: {}
 
   ieee754@1.2.1: {}
 
@@ -3057,6 +3088,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -3073,11 +3111,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plus@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)):
+  vite-plus@0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)):
     dependencies:
       '@oxc-project/types': 0.115.0
-      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)
-      '@voidzero-dev/vite-plus-test': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4))
+      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)
+      '@voidzero-dev/vite-plus-test': 0.1.11(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
       cac: 6.7.14
       cross-spawn: 7.0.6
       oxfmt: 0.40.0
@@ -3119,7 +3157,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4):
+  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -3131,6 +3169,7 @@ snapshots:
       '@types/node': 22.19.15
       esbuild: 0.27.4
       fsevents: 2.3.3
+      tsx: 4.21.0
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- https://github.com/TokiyaHorikawa/loopback/issues/2
- Hono + @hono/node-server を導入し、port 3000 でサーバー起動
- `GET /api/health` → `{"status":"ok"}` のヘルスチェックエンドポイント追加
- app定義とserve起動を分離し、vitest でテスト可能な構成に

## Test plan
- [x] `pnpm dev:server` でサーバー起動 → `curl localhost:3000/api/health` で `{"status":"ok"}` 確認済み
- [x] `pnpm test` で vitest パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)