### PR TITLE
feat: Review API を実装 (Issue #2 タスク 2-3)

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import goalsRoute from "./routes/goals.js";
+import reviewsRoute from "./routes/reviews.js";
 
 export const app = new Hono();
 
@@ -8,3 +9,4 @@ app.get("/api/health", (c) => {
 });
 
 app.route("/api/goals", goalsRoute);
+app.route("/api/reviews", reviewsRoute);

--- a/packages/server/src/routes/reviews.test.ts
+++ b/packages/server/src/routes/reviews.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@loopback/db";
+
+vi.mock("@loopback/db", async () => {
+  const actual = await vi.importActual<typeof import("@loopback/db")>("@loopback/db");
+  return {
+    ...actual,
+    getDb: vi.fn(),
+  };
+});
+
+import { app } from "../app.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.exec(`
+    CREATE TABLE goals (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      type text NOT NULL,
+      content text NOT NULL,
+      start_date text NOT NULL,
+      end_date text NOT NULL,
+      created_at text DEFAULT (datetime('now')) NOT NULL
+    );
+    CREATE TABLE reviews (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      type text NOT NULL,
+      content text NOT NULL,
+      date text NOT NULL,
+      created_at text DEFAULT (datetime('now')) NOT NULL
+    );
+    CREATE TABLE review_goals (
+      review_id integer NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+      goal_id integer NOT NULL REFERENCES goals(id) ON DELETE CASCADE,
+      PRIMARY KEY (review_id, goal_id)
+    );
+  `);
+  return drizzle(sqlite, { schema });
+}
+
+let testDb: ReturnType<typeof createTestDb>;
+
+beforeEach(() => {
+  testDb = createTestDb();
+  vi.mocked(schema.getDb).mockReturnValue(testDb as any);
+});
+
+function postReview(body: unknown) {
+  return app.request("/api/reviews", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function postGoal() {
+  return app.request("/api/goals", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "quarterly",
+      content: "Test goal",
+      start_date: "2026-01-01",
+      end_date: "2026-03-31",
+    }),
+  });
+}
+
+describe("POST /api/reviews", () => {
+  it("creates an interim review without goal_ids", async () => {
+    const res = await postReview({
+      type: "interim",
+      content: "順調に進んでいる",
+      date: "2026-02-15",
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe(1);
+    expect(body.type).toBe("interim");
+    expect(body.content).toBe("順調に進んでいる");
+    expect(body.date).toBe("2026-02-15");
+    expect(body.goal_ids).toEqual([]);
+    expect(body.created_at).toBeDefined();
+  });
+
+  it("creates an interim review with goal_ids", async () => {
+    await postGoal();
+    const res = await postReview({
+      type: "interim",
+      content: "中間レビュー",
+      date: "2026-02-15",
+      goal_ids: [1],
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.goal_ids).toEqual([1]);
+  });
+
+  it("creates a final review with exactly 1 goal_id", async () => {
+    await postGoal();
+    const res = await postReview({
+      type: "final",
+      content: "最終レビュー",
+      date: "2026-03-31",
+      goal_ids: [1],
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.type).toBe("final");
+    expect(body.goal_ids).toEqual([1]);
+  });
+
+  it("returns 400 for final review without goal_ids", async () => {
+    const res = await postReview({
+      type: "final",
+      content: "最終レビュー",
+      date: "2026-03-31",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for final review with 2+ goal_ids", async () => {
+    await postGoal();
+    await postGoal();
+    const res = await postReview({
+      type: "final",
+      content: "最終レビュー",
+      date: "2026-03-31",
+      goal_ids: [1, 2],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const res = await postReview({ type: "interim" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const res = await app.request("/api/reviews", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 for invalid type", async () => {
+    const res = await postReview({
+      type: "monthly",
+      content: "test",
+      date: "2026-02-15",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/reviews", () => {
+  it("returns empty array when no reviews exist", async () => {
+    const res = await app.request("/api/reviews");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("returns reviews ordered by id desc", async () => {
+    await postReview({
+      type: "interim",
+      content: "First review",
+      date: "2026-02-01",
+    });
+    await postReview({
+      type: "interim",
+      content: "Second review",
+      date: "2026-02-15",
+    });
+
+    const res = await app.request("/api/reviews");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].content).toBe("Second review");
+    expect(body[1].content).toBe("First review");
+  });
+
+  it("includes goal_ids in response", async () => {
+    await postGoal();
+    await postReview({
+      type: "interim",
+      content: "Review with goals",
+      date: "2026-02-15",
+      goal_ids: [1],
+    });
+
+    const res = await app.request("/api/reviews");
+    const body = await res.json();
+    expect(body[0].goal_ids).toEqual([1]);
+  });
+});
+
+describe("GET /api/reviews/:id", () => {
+  it("returns a review with goal_ids", async () => {
+    await postGoal();
+    await postReview({
+      type: "final",
+      content: "最終レビュー",
+      date: "2026-03-31",
+      goal_ids: [1],
+    });
+
+    const res = await app.request("/api/reviews/1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(1);
+    expect(body.content).toBe("最終レビュー");
+    expect(body.goal_ids).toEqual([1]);
+  });
+
+  it("returns 404 for non-existent review", async () => {
+    const res = await app.request("/api/reviews/999");
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/server/src/routes/reviews.ts
+++ b/packages/server/src/routes/reviews.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import { getDb, reviews, review_goals } from "@loopback/db";
+import { desc, eq } from "drizzle-orm";
+
+const app = new Hono();
+
+function getGoalIds(db: ReturnType<typeof getDb>, reviewId: number): number[] {
+  return db
+    .select({ goal_id: review_goals.goal_id })
+    .from(review_goals)
+    .where(eq(review_goals.review_id, reviewId))
+    .all()
+    .map((r) => r.goal_id);
+}
+
+app.get("/", (c) => {
+  const db = getDb();
+  const rows = db.select().from(reviews).orderBy(desc(reviews.id)).all();
+  const result = rows.map((row) => ({
+    ...row,
+    goal_ids: getGoalIds(db, row.id),
+  }));
+  return c.json(result);
+});
+
+app.get("/:id", (c) => {
+  const db = getDb();
+  const id = Number(c.req.param("id"));
+  const row = db.select().from(reviews).where(eq(reviews.id, id)).get();
+  if (!row) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  return c.json({ ...row, goal_ids: getGoalIds(db, row.id) });
+});
+
+type ReviewType = "interim" | "final";
+
+interface ReviewInput {
+  type: ReviewType;
+  content: string;
+  date: string;
+  goal_ids: number[];
+}
+
+function validateReviewBody(
+  body: Record<string, unknown>,
+): { data: ReviewInput } | { error: string } {
+  const { type, content, date } = body;
+
+  if (!type || !content || !date) {
+    return { error: "type, content, date are required" };
+  }
+
+  if (type !== "interim" && type !== "final") {
+    return { error: "type must be 'interim' or 'final'" };
+  }
+
+  const goalIds = (body.goal_ids as number[] | undefined) ?? [];
+
+  if (type === "final" && goalIds.length !== 1) {
+    return { error: "final review requires exactly 1 goal_id" };
+  }
+
+  return {
+    data: {
+      type,
+      content: content as string,
+      date: date as string,
+      goal_ids: goalIds,
+    },
+  };
+}
+
+app.post("/", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+
+  const validated = validateReviewBody(body);
+  if ("error" in validated) {
+    return c.json({ error: validated.error }, 400);
+  }
+
+  const { type, content, date, goal_ids: goalIds } = validated.data;
+
+  const db = getDb();
+  const result = db.insert(reviews).values({ type, content, date }).returning().get();
+
+  for (const goalId of goalIds) {
+    db.insert(review_goals).values({ review_id: result.id, goal_id: goalId }).run();
+  }
+
+  return c.json({ ...result, goal_ids: goalIds }, 201);
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- https://github.com/TokiyaHorikawa/loopback/issues/2
- `POST /api/reviews`, `GET /api/reviews`, `GET /api/reviews/:id` の3エンドポイントを追加
- interim/final タイプのバリデーション（final は goal_ids が exactly 1 必須）
- `review_goals` junction テーブル経由で goal との紐づけを管理

## Test plan
- [x] interim レビュー作成（goal_ids なし / あり）
- [x] final レビュー作成（goal_ids 1つ）
- [x] final で goal_ids なし / 2つ以上 → 400
- [x] 必須フィールド欠如・不正JSON・不正type → 400
- [x] GET 一覧: 空配列、id降順、goal_ids 含む
- [x] GET 単一: 正常取得、404
- [x] `pnpm test` 全20テスト通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)