### PR TITLE
fix: pre-commit フックの typecheck と lint エラーを修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,4 +11,7 @@ pre-commit:
 
     - name: typecheck
       glob: '*.{ts,tsx}'
-      run: pnpm tsc --build --noEmit
+      # --noEmit ではなく --build を使う理由:
+      # monorepo の project references を辿るには --build が必要で、
+      # --build は emit 前提のため --noEmit と併用すると TS6310 エラーになる。
+      run: pnpm typecheck

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,11 @@
     "declarationMap": true,
     "sourceMap": true
   },
+  // ルート tsconfig は solution-style（参照の集約のみ）として扱い、自身ではファイルをコンパイルしない。
+  // files: [] がないと vite.config.ts が暗黙的にコンパイルされ、生成される vite.config.js を
+  // oxlint v1.55.0 が設定ファイルとして誤認するバグを踏む。
+  // ref: oxlint の js_config.js が vite.config.ts のみ特別扱いし .js を処理しない問題
+  "files": [],
   "exclude": ["node_modules", "dist"],
   "references": [
     { "path": "./packages/db" },


### PR DESCRIPTION
## Summary
- lefthook の typecheck コマンドから `--noEmit` を削除。`--build` モードは emit 前提のため併用すると TS6310 エラーになる
- ルート `tsconfig.json` に `files: []` を追加し solution-style に変更。tsc が `vite.config.ts` をコンパイルして生成する `vite.config.js` を oxlint v1.55.0 が設定ファイルとして誤認するバグの回避策

## Test plan
- [ ] `pnpm typecheck` が通ること
- [ ] `pnpm lint` が通ること
- [ ] `git commit` が `--no-verify` なしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)