### PR TITLE
feat: MCP review ツール (save/list/find) を実装

### DIFF
--- a/packages/server/src/mcp.test.ts
+++ b/packages/server/src/mcp.test.ts
@@ -152,6 +152,209 @@ describe('create_goal tool', () => {
   })
 })
 
+describe('find_reviews tool', () => {
+  async function seedReviews() {
+    await app.request('/api/goals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'quarterly',
+        content: 'Goal',
+        start_date: '2026-01-01',
+        end_date: '2026-12-31',
+      }),
+    })
+    await app.request('/api/reviews', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'interim',
+        content: 'プロジェクトが順調',
+        date: '2026-03-01',
+        goal_ids: [1],
+      }),
+    })
+    await app.request('/api/reviews', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'final',
+        content: '目標を達成できた',
+        date: '2026-03-31',
+        goal_ids: [1],
+      }),
+    })
+    await app.request('/api/reviews', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'interim',
+        content: '来月に向けて準備',
+        date: '2026-04-15',
+      }),
+    })
+  }
+
+  it('returns all reviews up to limit when no filters', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 40,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10 },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews).toHaveLength(3)
+  })
+
+  it('filters by query', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 41,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, query: '順調' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews).toHaveLength(1)
+    expect(reviews[0].content).toBe('プロジェクトが順調')
+  })
+
+  it('filters by date range', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 42,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, from: '2026-03-01', to: '2026-03-31' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews).toHaveLength(2)
+  })
+
+  it('filters by type', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 43,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, type: 'final' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews).toHaveLength(1)
+    expect(reviews[0].type).toBe('final')
+  })
+
+  it('combines multiple filters', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 44,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, type: 'interim', from: '2026-04-01' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews).toHaveLength(1)
+    expect(reviews[0].content).toBe('来月に向けて準備')
+  })
+
+  it('returns error for invalid date format', async () => {
+    await mcpInitialize()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 45,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, from: 'invalid' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.result.isError).toBe(true)
+  })
+
+  it('returns error when from > to', async () => {
+    await mcpInitialize()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 46,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 10, from: '2026-04-01', to: '2026-03-01' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.result.isError).toBe(true)
+  })
+
+  it('includes goal_ids in results', async () => {
+    await mcpInitialize()
+    await seedReviews()
+
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 47,
+      method: 'tools/call',
+      params: {
+        name: 'find_reviews',
+        arguments: { limit: 1, type: 'final' },
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const reviews = JSON.parse(body.result.content[0].text)
+    expect(reviews[0].goal_ids).toEqual([1])
+  })
+})
+
 describe('list_reviews tool', () => {
   it('returns empty array when no reviews exist', async () => {
     await mcpInitialize()

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -4,9 +4,18 @@ import { z } from 'zod'
 
 import { getContext } from './services/context.js'
 import { createGoal } from './services/goals.js'
-import { createReview, getRecentReviews, getReviewsByGoalId } from './services/reviews.js'
+import {
+  createReview,
+  getRecentReviews,
+  getReviewsByGoalId,
+  searchReviews,
+} from './services/reviews.js'
 import { validateGoalInput } from './validators/goals.js'
-import { validateListReviewsInput, validateReviewInput } from './validators/reviews.js'
+import {
+  validateFindReviewsInput,
+  validateListReviewsInput,
+  validateReviewInput,
+} from './validators/reviews.js'
 
 export const mcpServer = new McpServer({
   name: 'loopback',
@@ -98,6 +107,33 @@ mcpServer.registerTool(
     const reviews = validated.data.goal_id
       ? getReviewsByGoalId(validated.data.goal_id, validated.data.limit)
       : getRecentReviews(validated.data.limit)
+    return {
+      content: [{ type: 'text', text: JSON.stringify(reviews) }],
+    }
+  },
+)
+
+mcpServer.registerTool(
+  'find_reviews',
+  {
+    description: 'limit, query?, from?, to?, type? で横断的にふりかえりを検索する',
+    inputSchema: {
+      limit: z.number(),
+      query: z.string().optional(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+      type: z.enum(['interim', 'final']).optional(),
+    },
+  },
+  ({ limit, query, from, to, type }) => {
+    const validated = validateFindReviewsInput({ limit, query, from, to, type })
+    if ('error' in validated) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: validated.error }) }],
+        isError: true,
+      }
+    }
+    const reviews = searchReviews(validated.data)
     return {
       content: [{ type: 'text', text: JSON.stringify(reviews) }],
     }

--- a/packages/server/src/repositories/reviews.ts
+++ b/packages/server/src/repositories/reviews.ts
@@ -1,5 +1,5 @@
 import { getDb, reviews, review_goals } from '@loopback/db'
-import { count, desc, eq, max } from 'drizzle-orm'
+import { and, count, desc, eq, gte, like, lte, max } from 'drizzle-orm'
 
 import type { ReviewInput } from '../validators/reviews.js'
 
@@ -57,6 +57,31 @@ export function findReviewsByGoalId(goalId: number, limit: number) {
     .where(eq(review_goals.goal_id, goalId))
     .orderBy(desc(reviews.id))
     .limit(limit)
+    .all()
+}
+
+export interface FindReviewsFilters {
+  limit: number
+  query?: string
+  from?: string
+  to?: string
+  type?: 'interim' | 'final'
+}
+
+export function findReviewsByFilters(filters: FindReviewsFilters) {
+  const db = getDb()
+  const conditions = []
+  if (filters.query) conditions.push(like(reviews.content, `%${filters.query}%`))
+  if (filters.from) conditions.push(gte(reviews.date, filters.from))
+  if (filters.to) conditions.push(lte(reviews.date, filters.to))
+  if (filters.type) conditions.push(eq(reviews.type, filters.type))
+
+  return db
+    .select()
+    .from(reviews)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(reviews.id))
+    .limit(filters.limit)
     .all()
 }
 

--- a/packages/server/src/services/reviews.ts
+++ b/packages/server/src/services/reviews.ts
@@ -35,6 +35,14 @@ export function getReviewStats() {
   return repo.getReviewStats()
 }
 
+export function searchReviews(filters: repo.FindReviewsFilters) {
+  const rows = repo.findReviewsByFilters(filters)
+  return rows.map((row) => ({
+    ...row,
+    goal_ids: repo.findGoalIdsByReviewId(row.id),
+  }))
+}
+
 export function createReview(input: ReviewInput) {
   const result = repo.insertReview(input)
 

--- a/packages/server/src/validators/reviews.ts
+++ b/packages/server/src/validators/reviews.ts
@@ -30,6 +30,52 @@ export function validateListReviewsInput(
   }
 }
 
+export interface FindReviewsInput {
+  limit: number
+  query?: string
+  from?: string
+  to?: string
+  type?: ReviewType
+}
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/
+
+export function validateFindReviewsInput(
+  body: Record<string, unknown>,
+): { data: FindReviewsInput } | { error: string } {
+  const { limit, query, from, to, type } = body
+
+  if (typeof limit !== 'number' || limit < 1) {
+    return { error: 'limit must be a positive number' }
+  }
+
+  if (from !== undefined && (typeof from !== 'string' || !datePattern.test(from))) {
+    return { error: 'from must be a date string (YYYY-MM-DD)' }
+  }
+
+  if (to !== undefined && (typeof to !== 'string' || !datePattern.test(to))) {
+    return { error: 'to must be a date string (YYYY-MM-DD)' }
+  }
+
+  if (from && to && from > to) {
+    return { error: 'from must be before or equal to to' }
+  }
+
+  if (type !== undefined && type !== 'interim' && type !== 'final') {
+    return { error: "type must be 'interim' or 'final'" }
+  }
+
+  return {
+    data: {
+      limit,
+      query: query as string | undefined,
+      from: from as string | undefined,
+      to: to as string | undefined,
+      type: type as ReviewType | undefined,
+    },
+  }
+}
+
 export function validateReviewInput(
   body: Record<string, unknown>,
 ): { data: ReviewInput } | { error: string } {


### PR DESCRIPTION
## Summary
- `save_review` ツール: type, content, date, goal_ids? でふりかえりを保存 (既存 validator/service を再利用)
- `list_reviews` ツール: limit, goal_id? でレビュー履歴取得 (goal_id フィルタ対応の repository/service 追加)
- `find_reviews` ツール: query/from/to/type による横断検索 (動的 WHERE 構築)

Closes #3 の 3-4, 3-5, 3-6

## Test plan
- [x] save_review: interim/final 作成、バリデーションエラー (3件)
- [x] list_reviews: 空配列、limit 制限、goal_id フィルタ、limit<=0 エラー (4件)
- [x] find_reviews: フィルタなし、query、日付範囲、type、複合フィルタ、不正日付、from>to、goal_ids 含有 (8件)
- [x] 全45テスト通過、lint/format/typecheck パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)